### PR TITLE
Allow original col names as keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    csv_hasher (0.0.0)
+    csv_hasher (0.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    csv_hasher (0.0.2)
+    csv_hasher (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ require 'csv_hasher'
 arr_of_hashes = CSVHasher.hashify('path/to/csv/file')
 ```
 
-By default the header column names are converted to keys of the hashes. If you want your own keys then pass the keys as a parameter
+By default the header column names are converted to keys of the hashes. These keys are Ruby Symbols spider cased. If you want the header values to remain as key Strings then use
+
+```shell
+arr_of_hashes = CSVHasher.hashify('path/to/csv/file', { original_col_as_keys: true })
+```
+
+If you want your own keys then pass your keys as a parameter.
 
 ```shell
 arr_of_hashes = CSVHasher.hashify('path/to/csv/file', { keys: custom_keys })

--- a/csv_hasher.gemspec
+++ b/csv_hasher.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name        = 'csv_hasher'
-  spec.version     = '0.0.2'
-  spec.date        = '2015-05-25'
+  spec.version     = '0.1.0'
+  spec.date        = '2015-05-27'
   spec.summary     = "CSV Hasher"
   spec.description = "A simple gem to return arrays of hashes for a CSV file"
   spec.authors     = ["Gaurav Singha Roy"]
@@ -10,6 +10,6 @@ Gem::Specification.new do |spec|
   spec.homepage    =
     'https://github.com/gsingharoy/csv_hasher'
   spec.license       = 'MIT'
-  
+
   spec.add_development_dependency "rspec"
 end

--- a/lib/csv_hasher.rb
+++ b/lib/csv_hasher.rb
@@ -20,16 +20,23 @@ class CSVHasher
   #
   def self.hashify(path_to_csv, options = { original_col_as_keys: false })
     csv_arrs = CSV.read(path_to_csv)
-    if options[:original_col_as_keys]
-      keys = csv_arrs[0]
-    else
-      keys = options[:keys] || col_keys(csv_arrs[0])
-    end
+    keys = csv_keys options, csv_arrs
     start_index = options[:keys].nil? || options[:include_headers] ? 1 : 0
     csv_arrs[start_index..-1].map {|a| Hash[keys.zip(a)] }
   end
 
   private
+
+  #This method gets the csv_keys based on the options and csv_arrs
+  def self.csv_keys(options, csv_arrs)
+    if options[:keys]
+      options[:keys]
+    elsif options[:original_col_as_keys]
+      csv_arrs[0]
+    else
+      col_keys(csv_arrs[0])
+    end
+  end
 
   # this method converts the header of the CSV into an array of sym keys
   def self.col_keys(keys)

--- a/lib/csv_hasher.rb
+++ b/lib/csv_hasher.rb
@@ -7,21 +7,31 @@ class CSVHasher
   # Example:
   #   >> CSVHasher.hashify('path/to/csv/file')
   #   => [{:col_1=> '..', :col_2=> '..'},...]
-  #   
+  #
   #
   # Arguments:
   #   path_to_csv: (String)
   #   options: (Hash)
-  def self.hashify(path_to_csv, options = {}) 
+  #            original_col_as_keys: (Boolean)
+  #                                   if original_col_as_keys is true then keys are exactly the col headers
+  #                                   if original_col_as_keys is false then keys are spidercase symbols from col headers
+  #            keys: (Array) Custom keys for the returned hashes
+  #
+  #
+  def self.hashify(path_to_csv, options = { original_col_as_keys: false })
     csv_arrs = CSV.read(path_to_csv)
-    keys = options[:keys] || col_keys(csv_arrs[0])
-    start_index = options[:keys].nil? || options[:include_headers] ? 1 : 0 
+    if options[:original_col_as_keys]
+      keys = csv_arrs[0]
+    else
+      keys = options[:keys] || col_keys(csv_arrs[0])
+    end
+    start_index = options[:keys].nil? || options[:include_headers] ? 1 : 0
     csv_arrs[start_index..-1].map {|a| Hash[keys.zip(a)] }
   end
 
-  private 
+  private
 
-  # this method converts the header of the CSV into an array of sym keys 
+  # this method converts the header of the CSV into an array of sym keys
   def self.col_keys(keys)
     keys.map{ |k| k.gsub('  ',' ').gsub(' ','_').downcase.to_sym }
   end

--- a/spec/lib/csv_hasher_spec.rb
+++ b/spec/lib/csv_hasher_spec.rb
@@ -9,11 +9,7 @@ describe CSVHasher do
       end
     end
     context 'when file exists' do
-      let(:sample1_path) { File.join(
-                              File.expand_path(File.dirname(__FILE__)),
-                              '..',
-                              'fixtures',
-                              'sample1.csv') }
+      let(:sample1_path) { csv_file_path(:sample1) }
       context 'sample1.csv file' do
         before do
           @header_keys = [:col_1, :col_2, :col_3]
@@ -94,5 +90,83 @@ describe CSVHasher do
         expect(CSVHasher.send(:col_keys, msg)).to eq expected_response
       end
     end
+  end
+
+  describe '::csv_keys' do
+    before do
+      @csv_arr = CSV.read csv_file_path(:sample1)
+    end
+    context 'original_col_as_keys' do
+      context 'when it is true' do
+        it 'returns the header names as it is for keys' do
+          options = { original_col_as_keys: true }
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq col_headers(:sample1, :original)
+        end
+      end
+      context 'when it is false' do
+        it 'returns the header names as symbols' do
+          options = { original_col_as_keys: false }
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq col_headers(:sample1, :symboled)
+        end
+      end
+      context 'when it is nil' do
+        it 'returns the header names as symbols' do
+          options = {}
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq col_headers(:sample1, :symboled)
+        end
+      end
+    end
+    context 'keys' do
+      context 'when it is nil' do
+        it 'returns the header names as symbols' do
+          options = {}
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq col_headers(:sample1, :symboled)
+        end
+      end
+      context 'when it has an array' do
+        it 'returns the passed array' do
+          keys = [1, 'col 2', :col_3]
+          options = { keys: keys }
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq keys
+        end
+      end
+      context 'when it has an array and original_col_as_keys is true' do
+        it 'returns the passed array' do
+          keys = [1, 'col 2', :col_3]
+          options = { keys: keys, original_col_as_keys: true }
+          expect(
+            CSVHasher.csv_keys(options, @csv_arr)
+          ).to eq keys
+        end
+      end
+    end
+  end
+
+  def col_headers(file_name = :sample1, type = :original)
+    if file_name == :sample1
+      if type == :original
+        ['col 1', 'col 2', 'col 3']
+      else
+        [:col_1, :col_2, :col_3]
+      end
+    end
+  end
+
+  def csv_file_path(file_name = :sample1)
+    File.join(
+    File.expand_path(File.dirname(__FILE__)),
+    '..',
+    'fixtures',
+    "#{file_name.to_s}.csv")
   end
 end

--- a/spec/lib/csv_hasher_spec.rb
+++ b/spec/lib/csv_hasher_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 describe CSVHasher do
-  describe '::hashify' do 
-    context 'when no file exists' do 
-      it 'raises error Errno::ENOENT' do 
+  describe '::hashify' do
+    context 'when no file exists' do
+      it 'raises error Errno::ENOENT' do
         expect{
           CSVHasher.hashify('/incorrect/path/to/csv')
         }.to raise_error Errno::ENOENT
       end
     end
-    context 'when file exists' do 
+    context 'when file exists' do
       let(:sample1_path) { File.join(
-                              File.expand_path(File.dirname(__FILE__)), 
-                              '..', 
-                              'fixtures', 
+                              File.expand_path(File.dirname(__FILE__)),
+                              '..',
+                              'fixtures',
                               'sample1.csv') }
-      context 'sample1.csv file' do 
-        before do 
-          @header_keys = [:col_1, :col_2, :col_3] 
+      context 'sample1.csv file' do
+        before do
+          @header_keys = [:col_1, :col_2, :col_3]
           @total_rows = 3
         end
-        it 'does not raise any error' do 
+        it 'does not raise any error' do
           expect{
             CSVHasher.hashify(sample1_path)
           }.to_not raise_error
         end
-        it 'returns the headers as keys' do 
+        it 'returns the headers as keys' do
           returned_arrs = CSVHasher.hashify(sample1_path)
           returned_arrs.each do |ra|
             expect(ra.keys).to eq @header_keys
           end
         end
-        it "returns #{@total_rows} hashes" do 
+        it "returns #{@total_rows} hashes" do
           expect(CSVHasher.hashify(sample1_path).count).to eq @total_rows
         end
         [1, 2, 3].each do |col_no|
@@ -43,8 +43,8 @@ describe CSVHasher do
             end
           end
         end
-        context 'when keys are passed in options parameter' do 
-          it 'returns arrays of hashes with the keys passed' do 
+        context 'when keys are passed in options parameter' do
+          it 'returns arrays of hashes with the keys passed' do
             msg_keys = ['col 1', 'col 2', 'col 3']
             returned_arrs = CSVHasher.hashify(sample1_path, { keys: msg_keys })
               returned_arrs.each do |ra|
@@ -52,34 +52,43 @@ describe CSVHasher do
             end
           end
         end
+        context 'when original_col_as_keys is true' do
+          it 'returns arrays of hashes with original headers as keys' do
+            col_arr = ['col 1', 'col 2', 'col 3']
+            returned_arrs = CSVHasher.hashify(sample1_path, { original_col_as_keys: true })
+            returned_arrs.each do |ra|
+              expect(ra.keys).to eq col_arr
+            end
+          end
+        end
       end
     end
   end
 
-  describe '::col_keys' do 
-    context 'when all keys are lower case' do 
-      it 'returns the keys as it is' do 
+  describe '::col_keys' do
+    context 'when all keys are lower case' do
+      it 'returns the keys as it is' do
         msg = ['foo', 'bar', 'lorem']
         expected_response = [:foo, :bar, :lorem]
         expect(CSVHasher.send(:col_keys, msg)).to eq expected_response
       end
     end
-    context 'when keys are capitalized' do 
-      it 'returns the keys in lower case' do 
+    context 'when keys are capitalized' do
+      it 'returns the keys in lower case' do
         msg = ['Foo', 'Bar', 'LOrem']
         expected_response = [:foo, :bar, :lorem]
         expect(CSVHasher.send(:col_keys, msg)).to eq expected_response
       end
     end
-    context 'when keys have spaces' do 
-      it 'returns the keys in spider case' do 
+    context 'when keys have spaces' do
+      it 'returns the keys in spider case' do
         msg = ['Foo Bar', 'Lorem  IPsum']
         expected_response = [:foo_bar, :lorem_ipsum]
         expect(CSVHasher.send(:col_keys, msg)).to eq expected_response
       end
     end
-    context 'when keys have numbers' do 
-      it 'returns numbers in the keys' do 
+    context 'when keys have numbers' do
+      it 'returns numbers in the keys' do
         msg = ['Foo Bar1', 'Lorem  IPsum2 4']
         expected_response = [:foo_bar1, :lorem_ipsum2_4]
         expect(CSVHasher.send(:col_keys, msg)).to eq expected_response


### PR DESCRIPTION
An option params is allowed which enables to customize the returned hashes's keys. The original header values can now be keys
